### PR TITLE
Fixed gemspec

### DIFF
--- a/likeable.gemspec
+++ b/likeable.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
     "Rakefile",
     "VERSION",
     "autotest/discover.rb",
-    "lib/.DS_Store",
     "lib/likeable.rb",
     "lib/likeable/facepile.rb",
     "lib/likeable/like.rb",


### PR DESCRIPTION
`The validation message from Rubygems was:
  ["lib/.DS_Store"] are not files`

Because lib/.DS_Store does no longer exist, it should be removed from likeable.gemspec.
Without this fix developers won't be able to install the gem.
