### PR TITLE
Adds after_unlike callback

### DIFF
--- a/lib/likeable/module_methods.rb
+++ b/lib/likeable/module_methods.rb
@@ -66,6 +66,12 @@ module Likeable
         @after_like
       end
 
+      def after_unlike(&block)
+        @after_unlike = block if block.present?
+        @after_unlike ||= lambda {|like|}
+        @after_unlike
+      end
+
       def adapter=(adapter)
         self.find_one  = adapter.find_one
         self.find_many = adapter.find_many

--- a/spec/likeable_spec.rb
+++ b/spec/likeable_spec.rb
@@ -123,6 +123,17 @@ describe Likeable do
         @target.add_like_from(@user)
       end
     end
+
+    describe 'after_unlike' do
+      it 'should be a class method when included' do
+        CleanTestClassForLikeable.respond_to?(:after_unlike).should be_true
+      end
+      it 'is called after a like is destroyed' do
+        CleanTestClassForLikeable.after_unlike(:foo)
+        @target.should_receive(:foo)
+        @target.remove_like_from(@user)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
As the name says.

I will also create a new pull request which combines the `after_unlike` callback with the same changes I did in #13 but for unliking. It does first a check if the like exists, and if not it doesn't call `after_unlike`.

Depending on what you need take either this one or #15.
