### PR TITLE
Improved specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,3 +27,5 @@ Jeweler::RubygemsDotOrgTasks.new
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
+
+task :default => [:spec]

--- a/lib/likeable.rb
+++ b/lib/likeable.rb
@@ -80,7 +80,7 @@ module Likeable
   def liked_by?(user)
     return false unless user
     liked_by =    @like_user_ids.include?(Likeable.cast_id(user.id)) if @like_user_ids
-    liked_by ||=  Likeable.redis.hexists(like_key, user.id)
+    liked_by ||=  true & Likeable.redis.hexists(like_key, user.id)
   end
 
 

--- a/spec/likeable/setup_spec.rb
+++ b/spec/likeable/setup_spec.rb
@@ -1,26 +1,6 @@
 require 'spec_helper'
 
 
-class LikeableIncludedInSetup
-
-end
-
-class SetupCleanTestClassForLikeable
-  include Likeable
-  def like_key
-    "like_key"
-  end
-
-  def to_hash(*args); {} end
-
-  def foo
-  end
-
-  def id
-    @id ||= rand(100)
-  end
-end
-
 describe Likeable do
   describe "setup" do
     context "when the User class is defined" do
@@ -28,7 +8,7 @@ describe Likeable do
         reload_user!
         Likeable.user_class = User
         @user   = User.new
-        @target = SetupCleanTestClassForLikeable.new
+        @target = CleanTestClassForLikeable.new
       end
 
       it "" do

--- a/spec/likeable_spec.rb
+++ b/spec/likeable_spec.rb
@@ -1,33 +1,22 @@
 require 'spec_helper'
-class CleanTestClassForLikeable
-  include Likeable
-  def like_key
-    "like_key"
-  end
-
-  def to_hash(*args); {} end
-
-  def foo
-  end
-
-  def id
-    @id ||= rand(100)
-  end
-end
-
-Likeable.setup do |like|
-  like.find_one = lambda {|klass, id| klass.where(:id => id)}
-end
 
 describe Likeable do
+
+  before(:all) do
+    Likeable.setup do |like|
+      like.find_one = lambda { |klass, id| klass.where(:id => id) }
+    end
+  end
 
   before(:each) do
     @user   = User.new
     @target = CleanTestClassForLikeable.new
   end
+
   describe 'instance methods' do
 
     describe "#add_like_from" do
+
       it "creates a like" do
         target_class = @target.class.to_s.downcase
         user_like_key = "users:like:#{@user.id}:#{target_class}"
@@ -37,9 +26,11 @@ describe Likeable do
         Likeable.redis.should_receive(:hset).with(user_like_key, @target.id, time).once
         @target.add_like_from(@user, time)
       end
+
     end
 
     describe "#remove_like_from" do
+
       it "removes a like" do
         target_class = @target.class.to_s.downcase
         user_like_key = "users:like:#{@user.id}:#{target_class}"
@@ -52,14 +43,17 @@ describe Likeable do
 
       it "doesn't call after_unlike if like didn't exist" do
         CleanTestClassForLikeable.after_unlike(:foo)
+        Likeable.redis.should_receive(:hexists).with("like_key", @user.id).and_return(false)
         @target = CleanTestClassForLikeable.new
         @target.should_not_receive(:foo)
         @target.remove_like_from(@user)
       end
+
     end
 
     describe "#liked_users" do
-      it "finds the users that like it" do
+
+      it "finds the users that like it", :integration do
         user1 = User.new :name => "user1"
         user2 = User.new :name => "user2"
         user1.like! @target
@@ -68,7 +62,7 @@ describe Likeable do
         @target.liked_users.should =~ [user1, user2]
       end
 
-      it "supports user id models where the id is a hash string" do
+      it "supports user id models where the id is a hash string", :integration do
         Likeable.cast_id = lambda { |id| id.to_s }
         user_id = "ce7961bd9ca9de6753b6e04754c1c615"
         @user.should_receive(:id).at_least(:once).and_return(user_id)
@@ -76,73 +70,91 @@ describe Likeable do
         User.should_receive(:where).with(:id => [user_id]).and_return([@user])
         @target.liked_users.should =~ [@user]
       end
+
     end
 
     describe "#likes" do
+
       it "returns set of likes" do
         Likeable.redis.should_receive(:hkeys).with("like_key").once
         @target.like_user_ids
       end
+
     end
 
     describe "#liked_by?" do
-      it "will answer if current user likes target" do
+
+      it "will answer if current user likes target", :integration do
         @target.should_not be_liked_by(@user)
         @user.like! @target
         @target.should be_liked_by(@user)
       end
 
-      it "works with hash string based user ids" do
+      it "works with hash string based user ids", :integration do
         user_id = "fa7961bd9ca9de6753b6e04754c1c615"
         @user.should_receive(:id).at_least(:once).and_return(user_id)
         @target.should_not be_liked_by(@user)
         @user.like! @target
         @target.should be_liked_by(@user)
       end
+
     end
 
     describe "#liked_friend_ids" do
+
       it "will return all friend ids of user who like target" do
         common_value = 3
         @target.should_receive(:like_user_ids).and_return([1,2, common_value])
         @user.should_receive(:friend_ids).and_return([common_value])
         @target.liked_friend_ids(@user).should == [common_value]
       end
+
     end
 
     describe "#liked_friends" do
+
       it "will return all friends who like object" do
         values = [1]
         @target.should_receive(:liked_friend_ids).with(@user).and_return(values)
         User.should_receive(:where).with(:id => values)
         @target.liked_friends(@user)
       end
+
     end
+
   end
 
   describe "class methods" do
+
     describe 'after_like' do
+
       it 'should be a class method when included' do
         CleanTestClassForLikeable.respond_to?(:after_like).should be_true
       end
+
       it 'is called after a like is created' do
         CleanTestClassForLikeable.after_like(:foo)
         @target.should_receive(:foo)
         @target.add_like_from(@user)
       end
+
     end
 
     describe 'after_unlike' do
+
       it 'should be a class method when included' do
         CleanTestClassForLikeable.respond_to?(:after_unlike).should be_true
       end
+
       it 'is called after a like is destroyed' do
         CleanTestClassForLikeable.after_unlike(:foo)
         Likeable.redis.should_receive(:hexists).and_return(true)
         @target.should_receive(:foo)
         @target.remove_like_from(@user)
       end
+
     end
+
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,48 +1,77 @@
 require 'rubygems'
 require 'active_record'
+require 'singleton'
+require 'tempfile'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../..', 'lib'))
 
 require 'likeable'
 
-def build_user!
-  eval %Q{
-      class User
-        include Likeable::UserMethods
-        def id
-          @time ||= Time.now.to_f.to_s.tr('.', '').to_i
-        end
+module UserHelperMethods
 
-        def self.where(*args)
-        end
+  def build_user!
+    eval %Q{
+        class ::User
+          include Likeable::UserMethods
+          def id
+            @time ||= Time.now.to_f.to_s.tr('.', '').to_i
+          end
 
-        def friends_ids
-          []
-        end
+          def self.where(*args)
+          end
 
-        def self.after_destroy
+          def friends_ids
+            []
+          end
+
+          def self.after_destroy
+          end
         end
-      end
-    }
+      }
+  end
+
+  def unload_user!
+    Object.instance_eval{ remove_const :User }
+  end
+
+  def reload_user!
+    unload_user!
+    build_user!
+  end
+
+  def default_adapter!
+    Likeable.adapter = Likeable::DefaultAdapter
+  end
+
 end
 
-def unload_user!
-  Object.instance_eval{ remove_const :User }
+RSpec.configure do |c|
+
+  c.include UserHelperMethods
+
+  c.treat_symbols_as_metadata_keys_with_true_values = true
+
+  c.before :suite do
+    Likeable.redis = NullRedis.new
+  end
+
+  c.before :each do
+    build_user!
+  end
+
+  c.around :each, :integration do |example|
+    IntegrationTestRedis.instance.start
+    Likeable.redis = IntegrationTestRedis.instance.client
+    Likeable.redis.flushdb
+    example.run
+    IntegrationTestRedis.instance.stop
+    Likeable.redis = NullRedis.new
+  end
+
 end
 
-def reload_user!
-  unload_user!
-  build_user!
-end
-
-def default_adapter!
-  Likeable.adapter = Likeable::DefaultAdapter
-end
-
-build_user!
-
-class NullRedis < BasicObject
+class NullRedis
 
   def method_missing(*args)
     self
@@ -54,42 +83,68 @@ class NullRedis < BasicObject
 
 end
 
-Likeable.redis = NullRedis.new
+class IntegrationTestRedis
 
-require 'tempfile'
-require 'rspec'
-require 'rspec/autorun'
+  include ::Singleton
 
-RSpec.configure do |config|
-  REDIS_PIDFILE = Tempfile.new("likeable-redis")
+  PORT    = 9737
+  PIDFILE = Tempfile.new('likeable-integration-test-redis-pid')
 
-  config.before(:suite) do
-    redis_options = {
-      "daemonize"     => 'yes',
-      "pidfile"       => REDIS_PIDFILE.path,
-      "bind"          => "127.0.0.1",
-      "port"          => 9737,
-      "timeout"       => 300,
-      "dir"           => "/tmp",
-      "loglevel"      => "debug",
-      "logfile"       => "stdout",
-      "databases"     => 16
-    }.map { |k, v| "#{k} #{v}" }.join('\n')
-    `echo '#{redis_options}' | redis-server -`
-
-    $redis_test_connection = Redis.new(:port => 9737, :db => 15)
+  def start
+    install_at_exit_handler
+    system("echo '#{options}' | redis-server -")
   end
 
-  config.before(:each) do
-    default_adapter!
-    $redis_test_connection.flushdb
-    Redis.stub(:new).and_return($redis_test_connection)
+  def stop
+    system("if [ -e #{PIDFILE.path} ]; then kill -QUIT $(cat #{PIDFILE.path}) 2>/dev/null; fi")
   end
 
-  # TODO this needs to handle premature exits, too
-  config.after(:suite) do
-    %x{
-      cat #{REDIS_PIDFILE.path} | xargs kill -QUIT
-    }
+  def client
+    return Redis.new(:port => PORT, :db => 15)
   end
+
+  private
+
+    def options
+      {
+        'daemonize'     => 'yes',
+        'pidfile'       => PIDFILE.path,
+        'bind'          => '127.0.0.1',
+        'port'          => PORT,
+        'timeout'       => 300,
+        'dir'           => '/tmp',
+        'loglevel'      => 'debug',
+        'logfile'       => 'stdout',
+        'databases'     => 16
+      }.map { |k, v| "#{k} #{v}" }.join("\n")
+    end
+
+    def install_at_exit_handler
+      at_exit {
+        IntegrationTestRedis.instance.stop
+      }
+    end
+
+end
+
+class CleanTestClassForLikeable
+
+  include Likeable
+
+  def like_key
+    "like_key"
+  end
+
+  def to_hash(*args);
+    Hash.new
+  end
+
+  def foo
+    nil
+  end
+
+  def id
+    @id ||= rand(100)
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,10 @@
 require 'rubygems'
 require 'active_record'
 
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../..', 'lib'))
 
-
 require 'likeable'
-
 
 def build_user!
   eval %Q{
@@ -45,6 +42,19 @@ end
 
 build_user!
 
+class NullRedis < BasicObject
+
+  def method_missing(*args)
+    self
+  end
+
+  def to_s
+    "Null Redis"
+  end
+
+end
+
+Likeable.redis = NullRedis.new
 
 require 'tempfile'
 require 'rspec'


### PR DESCRIPTION
The commit message says it all, this part of my work on merging @amrnt's work.

```
Improve the specs.

Improve the specs by running 30, of the 34 against a `NullRedis`
instance, a class with all methods returning a `NullObject`. This change
found two places where assumptions were being made, without being
mocked/stubbed correctly ("should not like by default", for example)

The two places that were making assumptions about the starting state
have now recieved explicit mocks/expectations to make clear the test
intention.

Added an `:integration` option to the specs which really need to talk to
Redis, there are 4 of these. The new real-redis has been re-implemented
as a Singleton class in `spec_helper.rb` where it is guaranteed to be
shut down by installing an `at_exit { }` block. This implementation is
mostly re-factored from the original.

The RSpec configuration has been cleaned-up, the `build_user!`,
`unload_user!` and related methods have been moved into a module, and
are available inside the RSpec scope.

The implementation of `CleanTestClassForLikeable` has been consolidated
from two similar (also **Setup**`CleanTestClassForLikeable`)
implementations in two different spec files, into one canonical
implementation in the spec helper.

The `Rakefile` is modified so that `rake` now defaults to running the
specs asif one had typed `rake spec`.
```
