### PR TITLE
use Likeable.user_class instead of User when looking up a Like.user

### DIFF
--- a/lib/likeable/like.rb
+++ b/lib/likeable/like.rb
@@ -16,7 +16,7 @@ class Likeable::Like
 
   def user
     @user ||= like_user
-    @user ||= Likeable.find_one(User, user_id)
+    @user ||= Likeable.find_one(Likeable.user_class, user_id)
     @user
   end
 

--- a/spec/likeable/like_spec.rb
+++ b/spec/likeable/like_spec.rb
@@ -18,4 +18,17 @@ describe Likeable::Like do
       like.created_at.should be_within(1).of(@time)
     end
   end
+  describe "#user" do
+    it "returns like_user if available" do
+      like = Likeable::Like.new(:target => @target, :user => @user, :time => @time)
+      like.user.should == @user
+    end
+    it "finds the user in the Likeable::user_model if the like was initialized without a user" do
+      like = Likeable::Like.new(:target => @target, :user => nil, :user_id => 100, :time => @time)
+      Account = stub()
+      Likeable.stub(:user_class).and_return(Account)
+      Likeable.should_receive(:find_one).with(Account, 100)
+      like.user
+    end
+  end
 end


### PR DESCRIPTION
Fixes the following bug: If a Like was instantiated without a user and has to look her up, it uses Likeable.find_one(User, user_id), ignoring the Likeable.user_class.
